### PR TITLE
Fix PPO update log probability computation

### DIFF
--- a/rl_agent/training_loop.py
+++ b/rl_agent/training_loop.py
@@ -66,7 +66,8 @@ def train_ppo(env, num_episodes, batch_size, training_queries):
         
         # PPO update
         for _ in range(10):  # Increase number of optimization epochs
-            new_log_probs, new_values = agent(states)
+            new_action_logits, new_values = agent(states)
+            new_log_probs = torch.log_softmax(new_action_logits, dim=-1)
             new_log_probs = new_log_probs.gather(1, actions.unsqueeze(1)).squeeze(1)
             new_values = new_values.squeeze(1)
             


### PR DESCRIPTION
## Summary
- fix PPO update step to compute log probabilities from logits

## Testing
- `python -m py_compile main.py rl_agent/*.py search_engine/*.py feedback_model/*.py evaluation/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68746b30fc348322a3f91c5b824af16d